### PR TITLE
Only underline links which are not components

### DIFF
--- a/src/RichText.vue
+++ b/src/RichText.vue
@@ -195,7 +195,7 @@ export default {
 }
 </script>
 <style scoped>
-a {
+a:not(.rich-text--component) {
 	text-decoration: underline;
 }
 </style>


### PR DESCRIPTION
Before | After
---|---
![Bildschirmfoto vom 2022-09-14 21-58-18](https://user-images.githubusercontent.com/213943/190251976-e3709462-eb09-40fb-b8a2-d83f2cb9dda1.png) | ![Bildschirmfoto vom 2022-09-14 22-08-07](https://user-images.githubusercontent.com/213943/190252118-e8d7a3ee-54c9-48dd-a7d0-4f3a3a1da930.png)


And we somewhat need a 2.0.1 after this 😿 