### PR TITLE
Fix leading and trailing spaces on the URLs

### DIFF
--- a/src/ReferenceList.vue
+++ b/src/ReferenceList.vue
@@ -75,7 +75,7 @@ export default {
 			})
 		},
 		resolve() {
-			const match = (new RegExp(URL_PATTERN).exec(this.text))
+			const match = (new RegExp(URL_PATTERN).exec(this.text.trim()))
 			if (this.limit === 1 && match) {
 				return axios.get(generateOcsUrl('references/resolve', 2) + `?reference=${encodeURIComponent(match[0])}`)
 			}


### PR DESCRIPTION
Company log is being spamed by
```
Could not detect any host in  https://github.com/nextcloud
```
 at the moment.

Note the double space before the url. It's the white space matched by the regex from the beginning of:
https://github.com/nextcloud/vue-richtext/blob/d85ed78990833c8f29828d369ae387bbd9b4d8a6/src/helpers.js#L1

I currently added a trim on the servers controller as a work around, but this here would also be a fix I guess.