### PR TITLE
Make getLinkWithPicker simpler

### DIFF
--- a/src/referencePicker/referencePickerModal.js
+++ b/src/referencePicker/referencePickerModal.js
@@ -1,23 +1,28 @@
 import Vue from 'vue'
 import ReferencePickerModal from './ReferencePickerModal.vue'
+import { getProvider } from './providerHelper.js'
 
 /**
  * Creates a reference picker modal and return a promise which provides the result
  *
- * @param {Object} provider
+ * @param {String} providerId Optional ID of initial selected provider
  * @returns {Promise<unknown>}
  */
-export async function getLinkWithPicker(provider) {
+export async function getLinkWithPicker(providerId = null) {
 	return await new Promise((resolve, reject) => {
 		const modalId = 'referencePickerModal'
 		const modalElement = document.createElement('div')
 		modalElement.id = modalId
 		document.body.append(modalElement)
 
+		const initialProvider = providerId === null
+			? null
+			: (getProvider(providerId) ?? null)
+
 		const View = Vue.extend(ReferencePickerModal)
 		const view = new View({
 			propsData: {
-				initialProvider: provider,
+				initialProvider,
 			},
 		}).$mount(modalElement)
 


### PR DESCRIPTION
It makes more sense to only pass the provider ID to the helper function to invoke the link picker instead of the full provider object.

If that's fine we could make a vue-richtext release after this is merged. I'll make the adjustment in Text and nextcloud/vue.