### PR TITLE
Fix getProvider not getting the 'any-link' one

### DIFF
--- a/src/package.js
+++ b/src/package.js
@@ -6,7 +6,7 @@ import ReferencePicker from './referencePicker/ReferencePicker.vue'
 import ReferencePickerModal from './referencePicker/ReferencePickerModal.vue'
 import Search from './referencePicker/Search.vue'
 import { getLinkWithPicker } from './referencePicker/referencePickerModal.js'
-import { getProvider, getProviders, sortProviders, searchProvider } from './referencePicker/providerHelper.js'
+import { getProvider, getProviders, sortProviders, searchProvider, anyLinkProviderId } from './referencePicker/providerHelper.js'
 import { registerCustomPickerElement, renderCustomPickerElement, isCustomPickerElementRegistered, CustomPickerRenderResult } from './referencePicker/customPickerElements'
 
 export default RichText
@@ -28,6 +28,7 @@ export {
 	renderCustomPickerElement,
 	isCustomPickerElementRegistered,
 	getLinkWithPicker,
+	anyLinkProviderId,
 	getProvider,
 	getProviders,
 	sortProviders,

--- a/src/referencePicker/providerHelper.js
+++ b/src/referencePicker/providerHelper.js
@@ -26,6 +26,9 @@ if (!window._vue_richtext_reference_provider_timestamps) {
  * @returns {Object} The provider object
  */
 export function getProvider(providerId) {
+	if (providerId === 'any-link') {
+		return anyLinkProvider
+	}
 	return getProviders().find(p => p.id === providerId)
 }
 

--- a/src/referencePicker/providerHelper.js
+++ b/src/referencePicker/providerHelper.js
@@ -4,8 +4,10 @@ import axios from '@nextcloud/axios'
 
 import { isCustomPickerElementRegistered } from './customPickerElements.js'
 
+export const anyLinkProviderId = 'any-link'
+
 const anyLinkProvider = {
-	id: 'any-link',
+	id: anyLinkProviderId,
 	// TODO translate
 	title: 'Any link',
 	icon_url: imagePath('core', 'filetypes/link.svg'),
@@ -26,7 +28,7 @@ if (!window._vue_richtext_reference_provider_timestamps) {
  * @returns {Object} The provider object
  */
 export function getProvider(providerId) {
-	if (providerId === 'any-link') {
+	if (providerId === anyLinkProviderId) {
 		return anyLinkProvider
 	}
 	return getProviders().find(p => p.id === providerId)


### PR DESCRIPTION
Which causes the reference picker to be in "provider selection" state when `getLinkWithPicker('any-link')` is called.