### PR TITLE
Fix circular dependency with nc/vue

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -15,7 +15,7 @@ export default defineConfig({
 			formats: ['es'],
 		},
 		rollupOptions: {
-			external: Object.keys(dependencies),
+			external: Object.keys(dependencies).filter(e => e !== '@nextcloud/vue'),
 			output: {
 				globals: { vue: 'Vue' }
 			},


### PR DESCRIPTION
Do not include nc/vue in rollup pkgs to avoid circular dependency.